### PR TITLE
Fix erratic behavior when some keys in path are equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,25 +63,6 @@ Storage.prototype.get = function (key) {
 
 Storage.prototype._getDeep = function (path) {
   var storage = this.store;
-  var dest = path[path.length - 1];
-  var key;
-
-  for (var i = 0; i < path.length; i++) {
-    key = path[i];
-
-    if (isObject(storage)) {
-      storage = storage[key];
-    } else {
-      break;
-    }
-  }
-
-  return key === dest ? storage : undefined;
-};
-
-Storage.prototype._setDeep = function (path, value, remove) {
-  var storage = this.store;
-  var dest = path[path.length - 1];
 
   for (var i = 0; i < path.length; i++) {
     var p = path[i];
@@ -91,15 +72,32 @@ Storage.prototype._setDeep = function (path, value, remove) {
     }
 
     if (!storage.hasOwnProperty(p)) {
-      if (p === dest) {
-        setOrRemove(storage, p);
-        break;
-      } else {
-        storage[p] = {};
-      }
-    } else if (p === dest) {
+      return undefined;
+    }
+
+    storage = storage[p];
+  }
+
+  return storage;
+};
+
+Storage.prototype._setDeep = function (path, value, remove) {
+  var storage = this.store;
+
+  for (var i = 0; i < path.length; i++) {
+    var p = path[i];
+
+    if (!isObject(storage)) {
+      throw new Error(path.slice(0, i).join('.') + ' is not an object');
+    }
+
+    if (i === path.length - 1) {
       setOrRemove(storage, p);
-      break;
+      return;
+    }
+
+    if (!storage.hasOwnProperty(p)) {
+      storage[p] = {};
     }
 
     storage = storage[p];

--- a/test/store.js
+++ b/test/store.js
@@ -132,7 +132,15 @@ describe('Storage', function () {
 
   it('should throw an error when dot-syntax string contains value that is not an object', function () {
     Store.put('very.nested', 10);
+    Store.get.bind(Store, 'very.nested.object.key').should.throwError(/^very.nested .+/);
     Store.put.bind(Store, 'very.nested.object.key', 111).should.throwError(/^very.nested .+/);
   });
 
+  it('should properly handle multiple equal keys on a path', function () {
+    Store.put('x.a.b.c.a.b', 1);
+    Store.get('x').should.eql({ a: { b: { c: { a: { b: 1 } } } } });
+
+    Store.put('y', { a: 2 });
+    Store.get.bind(Store, 'y.a.b.c.a.b').should.throwError();
+  });
 });


### PR DESCRIPTION
The storage gets confused if multiple keys on a path have same name (e.g. 'a.b.c.a.b').
The problem was in `_getDeep` and `_setDeep` methods, in particular condition `p === dest` or `key === dest` can be satisfied on earlier keys in the path.
This pull request fixes that, and also allows `get` to report `Error('... is not an object')` consistently with `put`.

```
var Storage = require('node-storage');
var store = new Storage('db');

store.put('x.a.b.c.a.b', 1);
console.log(store.get('x').a.b);
// old: 1
// new: { c: { a: { b: 1 } } }

store.put('y', { a: 2 });
try { console.log(store.get('y.a.b.c.a.b')); } catch (err) { console.log(err.message); }
// old: 2
// new: Error('y.a is not an object'); // for consistency with put

store.put('z', {});
console.log(store.get('z.a.b.c.a.b'));
// old: undefined, but somewhat non-intuitive code-path, see below
// new: undefined, consistent with store.put('z.a.b.c.a.b', ...);
//      which will not throw an error in this case
```

For the last case the return is in `index.js:79`, `key === dest` is true, returns `storage` which happens to be `undefined`, should return `undefined` from second branch, because it never got to the end of path.

Sorry that I didn't include tests in the patch, I wasn't able to run the test framework.
